### PR TITLE
fix: replaced data.ExecuteAction with data.Execute

### DIFF
--- a/src/apollo-links/index.ts
+++ b/src/apollo-links/index.ts
@@ -33,11 +33,11 @@ async function refreshToken(platformId: string): Promise<string | null> {
       },
     });
 
-    if (!res.data || !res.data.data || !res.data.data.ExecuteAction) {
+    if (!res.data || !res.data.data || !res.data.data.Execute) {
       return null;
     }
 
-    const response = JSON.parse(res.data.data.ExecuteAction);
+    const response = JSON.parse(res.data.data.Execute);
 
     if (
       !response.id ||

--- a/src/components/NoStackContext/NoStackContext.spec.tsx
+++ b/src/components/NoStackContext/NoStackContext.spec.tsx
@@ -37,7 +37,7 @@ describe('<NoStackConsumer />', () => {
 
   const queryHandler = jest.fn().mockResolvedValue({
     data: {
-      ExecuteAction: JSON.stringify({
+      Execute: JSON.stringify({
         ...mockUser,
       }),
     },
@@ -198,7 +198,7 @@ describe('withNoStack() HOC', () => {
 
   const queryHandler = jest.fn().mockResolvedValue({
     data: {
-      ExecuteAction: JSON.stringify({
+      Execute: JSON.stringify({
         ...mockUser,
       }),
     },

--- a/src/components/NoStackContext/index.tsx
+++ b/src/components/NoStackContext/index.tsx
@@ -144,7 +144,7 @@ class RawNoStackProvider extends Component<ProviderProps, ProviderState> {
       return { error: err };
     });
 
-    if (res.error || !res.data || !res.data.ExecuteAction) {
+    if (res.error || !res.data || !res.data.Execute) {
       if (res.error.networkError) {
         throw res.error.networkError;
       }
@@ -156,7 +156,7 @@ class RawNoStackProvider extends Component<ProviderProps, ProviderState> {
       throw new Error('Unknown error.');
     }
 
-    const response = JSON.parse(res.data.ExecuteAction);
+    const response = JSON.parse(res.data.Execute);
 
     if (
       !response.id ||
@@ -239,11 +239,11 @@ class RawNoStackProvider extends Component<ProviderProps, ProviderState> {
       return { error: err };
     });
 
-    if (res.error || !res.data || !res.data.ExecuteAction) {
+    if (res.error || !res.data || !res.data.Execute) {
       return this.logout();
     }
 
-    const response = JSON.parse(res.data.ExecuteAction);
+    const response = JSON.parse(res.data.Execute);
 
     if (
       !response.id ||
@@ -286,11 +286,11 @@ class RawNoStackProvider extends Component<ProviderProps, ProviderState> {
       return { error: err };
     });
 
-    if (res.error || !res.data || !res.data.ExecuteAction) {
+    if (res.error || !res.data || !res.data.Execute) {
       throw new Error('Expired/Invalid Token');
     }
 
-    const response = JSON.parse(res.data.ExecuteAction);
+    const response = JSON.parse(res.data.Execute);
 
     if (
       !response.id ||
@@ -327,7 +327,7 @@ class RawNoStackProvider extends Component<ProviderProps, ProviderState> {
 }
 
 export interface Response {
-  ExecuteAction: string;
+  Execute: string;
 }
 
 export interface Variables {

--- a/src/components/Unit/index.tsx
+++ b/src/components/Unit/index.tsx
@@ -27,7 +27,7 @@ export interface Instance {
 }
 
 export interface Response {
-  ExecuteAction: string;
+  Execute: string;
 }
 
 export const Unit: React.FunctionComponent<UnitInterface> = ({
@@ -60,7 +60,7 @@ export const Unit: React.FunctionComponent<UnitInterface> = ({
     if (instance) {
       newInstance = instance;
     } else {
-      const data = response.data && JSON.parse(response.data.ExecuteAction);
+      const data = response.data && JSON.parse(response.data.Execute);
 
       newInstance = {
         id: data.instanceId,
@@ -95,7 +95,7 @@ export const Unit: React.FunctionComponent<UnitInterface> = ({
     instanceId: string,
     fragment: DocumentNode,
   ): MutationUpdaterFn<Response> => (cache, response): void => {
-    const data = response.data && JSON.parse(response.data.ExecuteAction);
+    const data = response.data && JSON.parse(response.data.Execute);
 
     cache.writeFragment({
       id: `${instanceId}Instance`,


### PR DESCRIPTION
The new server uses Execute rather than ExecuteAction, which returns a key "Execute" instead of
"ExecuteAction"