### PR TITLE
fix: removed executions ids from auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,10 +611,10 @@ a mutation helper you can plug into Apollo's `<Mutation>` component called `EXEC
 
 ```javascript
 import { Mutation } from '@apollo/react-components';
-import { EXECUTE_ACTION } from '@nostack/no-stack';
+import { EXECUTE } from '@nostack/no-stack';
 
 const YourComponent = () => (
-  <Mutation mutation={EXECUTE_ACTION} >
+  <Mutation mutation={EXECUTE} >
   {(executeAction, { data }) =>
     if (data) {
       console.log(data);
@@ -642,7 +642,7 @@ Or, via Apollo's `graphql` HOC:
 
 ```javascript
 import { graphql } from '@apollo/react-hoc';
-import { EXECUTE_ACTION } from '@nostack/no-stack';
+import { EXECUTE } from '@nostack/no-stack';
 
 const YourComponent = ({ executeAction }) => (
   <div>
@@ -663,18 +663,18 @@ const YourComponent = ({ executeAction }) => (
 );
 
 export default graphql(
-  EXECUTE_ACTION,
+  EXECUTE,
   {
     name: 'executeAction',
   },
 )(YourComponent);
 ```
 
-Depending on its type, the action called with `EXECUTE_ACTION` can perform different
+Depending on its type, the action called with `EXECUTE` can perform different
 mutations, including but not limited to creating/updating/deleting instances, logging
 in/out, and user registration.
 
-#### EXECUTE_ACTION SIGNATURE
+#### EXECUTE SIGNATURE
 
 | Variable            | Description                                                             | Value                                                      | Required              |
 | ------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------- | --------------------- |

--- a/src/apollo-links/index.ts
+++ b/src/apollo-links/index.ts
@@ -4,7 +4,7 @@ import { HttpLink } from 'apollo-link-http';
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
 
-import { EXECUTE_ACTION } from '../mutations';
+import { EXECUTE } from '../mutations';
 import { NO_STACK_URI } from '../config';
 
 async function refreshToken(platformId: string): Promise<string | null> {
@@ -23,7 +23,7 @@ async function refreshToken(platformId: string): Promise<string | null> {
       url: NO_STACK_URI,
       method: 'post',
       data: {
-        query: EXECUTE_ACTION,
+        query: EXECUTE,
         variables: {
           // REFRESH TOKEN ACTION
           actionId: '96d3be63-53c5-418e-9167-71e3d43271e3',

--- a/src/components/NoStackContext/NoStackContext.spec.tsx
+++ b/src/components/NoStackContext/NoStackContext.spec.tsx
@@ -3,7 +3,7 @@ import { render, wait, fireEvent } from '@testing-library/react';
 import { createMockClient } from 'mock-apollo-client';
 import faker from 'faker';
 
-import { EXECUTE_ACTION } from 'mutations';
+import { EXECUTE } from 'mutations';
 
 import { NoStackProvider, NoStackConsumer, withNoStack } from '.';
 
@@ -43,7 +43,7 @@ describe('<NoStackConsumer />', () => {
     },
   });
 
-  mockClient.setRequestHandler(EXECUTE_ACTION, queryHandler);
+  mockClient.setRequestHandler(EXECUTE, queryHandler);
 
   beforeEach(() => {
     store = {};
@@ -204,7 +204,7 @@ describe('withNoStack() HOC', () => {
     },
   });
 
-  mockClient.setRequestHandler(EXECUTE_ACTION, queryHandler);
+  mockClient.setRequestHandler(EXECUTE, queryHandler);
 
   beforeEach(() => {
     store = {};

--- a/src/components/NoStackContext/index.tsx
+++ b/src/components/NoStackContext/index.tsx
@@ -10,7 +10,7 @@ import { ApolloProvider, MutationFunction } from '@apollo/react-common';
 import { ApolloClient, ApolloError } from 'apollo-client';
 import { NormalizedCache } from 'apollo-cache-inmemory';
 
-import { EXECUTE_ACTION } from '../../mutations';
+import { EXECUTE } from '../../mutations';
 
 export interface User {
   id: string;
@@ -153,13 +153,14 @@ class RawNoStackProvider extends Component<ProviderProps, ProviderState> {
         throw res.error.graphQLErrors[0];
       }
 
-      throw new Error('Unknown error.');
+      console.log(`error logging ins: ${JSON.stringify(res.error, null, 2)}`);
+
+      throw new Error('Unknown error logging in.');
     }
 
     const response = JSON.parse(res.data.Execute);
 
     if (
-      !response.id ||
       !response.userId ||
       !response.userName ||
       !response.role ||
@@ -167,7 +168,7 @@ class RawNoStackProvider extends Component<ProviderProps, ProviderState> {
       !response.AuthenticationResult.AccessToken ||
       !response.AuthenticationResult.RefreshToken
     ) {
-      throw new Error('Unknown error.');
+      throw new Error('Missing data from server on login.');
     }
 
     this.setUser(
@@ -246,7 +247,6 @@ class RawNoStackProvider extends Component<ProviderProps, ProviderState> {
     const response = JSON.parse(res.data.Execute);
 
     if (
-      !response.id ||
       !response.AuthenticationResult ||
       !response.AuthenticationResult.AccessToken
     ) {
@@ -292,12 +292,7 @@ class RawNoStackProvider extends Component<ProviderProps, ProviderState> {
 
     const response = JSON.parse(res.data.Execute);
 
-    if (
-      !response.id ||
-      !response.userId ||
-      !response.role ||
-      !response.accessToken
-    ) {
+    if (!response.userId || !response.role || !response.accessToken) {
       throw new Error('Expired/Invalid Token');
     }
 
@@ -342,7 +337,7 @@ export const NoStackProvider: FunctionComponent<{
   children: React.ReactNode;
 }> = ({ client, platformId, children }): JSX.Element => (
   <ApolloProvider client={client}>
-    <Mutation mutation={EXECUTE_ACTION}>
+    <Mutation mutation={EXECUTE}>
       {(loginUser: MutationFunction): JSX.Element => (
         <RawNoStackProvider
           client={client}

--- a/src/mutations/index.ts
+++ b/src/mutations/index.ts
@@ -1,18 +1,18 @@
 import gql from 'graphql-tag';
 
-export const EXECUTE_ACTION = gql`
-  mutation EXECUTE_ACTION(
-    $actionId: ID!
-    $executionParameters: String
-    $unrestricted: Boolean
-  ) {
-    Execute(
-      actionId: $actionId
-      executionParameters: $executionParameters
-      unrestricted: $unrestricted
-    )
-  }
-`;
+// export const EXECUTE_ACTION = gql`
+//   mutation EXECUTE_ACTION(
+//     $actionId: ID!
+//     $executionParameters: String
+//     $unrestricted: Boolean
+//   ) {
+//     Execute(
+//       actionId: $actionId
+//       executionParameters: $executionParameters
+//       unrestricted: $unrestricted
+//     )
+//   }
+// `;
 
 export const EXECUTE = gql`
   mutation EXECUTE(


### PR DESCRIPTION
Login was failing because of execution ids being expected and not being returned by the new server.
They weren't being used in the code anyway.